### PR TITLE
fix(presence): dedupe activities across a user's sockets

### DIFF
--- a/src/cache/UserCache.ts
+++ b/src/cache/UserCache.ts
@@ -7,6 +7,7 @@ import { prisma, publicUserExcludeFields } from '../common/database';
 import { removeDuplicates } from '../common/utils';
 import { hasBit, USER_BADGES } from '../common/Bitwise';
 import { addDeviceWithSession, DeviceTypeId } from '@src/services/User/UserManagement';
+import { dedupeActivities } from './utils/presenceUtils';
 
 export interface ActivityStatus {
   socketId: string;
@@ -176,6 +177,7 @@ export async function getUserPresences(opts: GetUserPresencesOpts): Promise<Pres
     if (hideOffline && presence.status === UserStatus.OFFLINE) continue;
     if (!includeSocketId) {
       presence.activities = presence.activities?.map((a) => ({ ...a, socketId: undefined })) as ActivityStatus[] | undefined;
+      presence.activities = dedupeActivities(presence.activities);
     }
     presence.activities = limitActivities ? presence.activities?.slice(0, 5) : presence.activities;
     presences.push(presence);
@@ -349,16 +351,16 @@ async function storeUserCache(userId: string, beforeCache?: (user: UserCache) =>
   const userCache: UserCache = {
     ...(user.account
       ? {
-          account: {
-            id: user.account!.id,
-            emailConfirmed: user.account!.emailConfirmed,
-          },
-        }
+        account: {
+          id: user.account!.id,
+          emailConfirmed: user.account!.emailConfirmed,
+        },
+      }
       : {
-          application: {
-            id: user.application!.id,
-          },
-        }),
+        application: {
+          id: user.application!.id,
+        },
+      }),
     ...(user.shadowBan ? { shadowBanned: true } : {}),
     id: user.id,
     username: user.username,

--- a/src/cache/utils/presenceUtils.ts
+++ b/src/cache/utils/presenceUtils.ts
@@ -1,0 +1,14 @@
+import type { ActivityStatus } from "../UserCache";
+
+// collapse duplicate extenal activities reported by mutiple
+// client sockets
+export function dedupeActivities(activities?: ActivityStatus[] | null) {
+  if (!activities) return activities;
+  const seen = new Set<string>();
+  return activities.filter((a) => {
+    const key = [a.name, a.action, a.title, a.subtitle, a.link, a.imgSrc].join('\u0000');
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/src/cache/utils/presenceUtils.ts
+++ b/src/cache/utils/presenceUtils.ts
@@ -1,6 +1,6 @@
 import type { ActivityStatus } from "../UserCache";
 
-// collapse duplicate extenal activities reported by mutiple
+// collapse duplicate external activities reported by multiple
 // client sockets
 export function dedupeActivities(activities?: ActivityStatus[] | null) {
   if (!activities) return activities;


### PR DESCRIPTION
## What does this PR do?
Fixes duplicate RPC entries that showed up when the same user had two clients (or more) connected at once

## Changes Made
- new `presenceUtils.ts` with `dedupeActivities()`
- gets called in `getUserPresences` in the UserCache on the public path only, before the slice

## Checklist
- [x] Code is clear, concise & easy to understand
- [x] Code has been tested and works as intended  
- [ ] Documentation or README has been updated if relevant  
- [x] Security and error handling considerations have been addressed  
- [ ] Has the change been previously discussed with backend maintainer(s)

## Testing
Two clients in one account, same activity: showed twice before, once after. Confirmed with web client + synced Discord

## Additional Notes
https://github.com/user-attachments/assets/17d38877-baed-4679-bd94-67149d5ed653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presence/activity handling so duplicate activities are no longer shown.
  * Kept user cache data consistent while building presence information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->