### PR TITLE
Added Masqurade feature and the coresponding permision

### DIFF
--- a/src/common/Bitwise.ts
+++ b/src/common/Bitwise.ts
@@ -245,6 +245,12 @@ export const ROLE_PERMISSIONS = {
     name: 'Mention Roles',
     bit: 1 << 8,
   },
+  MASQUERADE: {
+    name: 'Masquerade',
+    description: 'Allow members to change name and avatar per-message',
+    bit: 1 << 9,
+    icon: 'person',
+  },
 };
 
 export const APPLICATION_SCOPES = {

--- a/src/routes/channels/channelMessageCreate.ts
+++ b/src/routes/channels/channelMessageCreate.ts
@@ -272,6 +272,9 @@ async function route(req: Request, res: Response) {
   if (!canMasquerade) {
     return res.status(403).json(generateError('You do not have permission to masquerade yourself.'));
   }
+  if (req.channelCache.type === ChannelType.DM_TEXT) {
+    return res.status(403).json(generateError('You cannot use masquerade in DM channels.'));
+  }
 }
 
   let attachment: Partial<Attachment> | undefined = undefined;

--- a/src/routes/channels/channelMessageCreate.ts
+++ b/src/routes/channels/channelMessageCreate.ts
@@ -38,8 +38,8 @@ export function channelMessageCreate(Router: Router) {
     memberHasRolePermissionMiddleware(ROLE_PERMISSIONS.SEND_MESSAGE),
     body('content').optional(true).isString().withMessage('Content must be a string!').isLength({ min: 1, max: 2000 }).withMessage('Content length must be between 1 and 2000 characters.'),
     body('socketId').optional(true).isString().withMessage('SocketId must be a string!').isLength({ min: 1, max: 255 }).withMessage('SocketId length must be between 1 and 255 characters.'),
-    body('avatarUrl').optional(true).isString().withMessage('Avatar URL must be a string!').isLength({ min: 1, max: 255 }).withMessage('Avatar URL length must be between 1 and 255 characters.'),
-    body('username').optional(true).isString().withMessage('Invalid username.').not().contains('@').withMessage('Username cannot contain the @ symbol').not().contains(':').withMessage('Username cannot contain the : symbol').isLength({ min: 3, max: 35 }).withMessage('Username must be between 3 and 35 characters long.'),
+    body('avatar_url_override').optional(true).isString().withMessage('Avatar URL must be a string!').isLength({ min: 1, max: 255 }).withMessage('Avatar URL length must be between 1 and 255 characters.'),
+    body('username_override').optional(true).isString().withMessage('Invalid username.').not().contains('@').withMessage('Username cannot contain the @ symbol').not().contains(':').withMessage('Username cannot contain the : symbol').isLength({ min: 3, max: 35 }).withMessage('Username must be between 3 and 35 characters long.'),
 
     body('replyToMessageIds')
       .optional(true)

--- a/src/routes/channels/channelMessageCreate.ts
+++ b/src/routes/channels/channelMessageCreate.ts
@@ -38,6 +38,8 @@ export function channelMessageCreate(Router: Router) {
     memberHasRolePermissionMiddleware(ROLE_PERMISSIONS.SEND_MESSAGE),
     body('content').optional(true).isString().withMessage('Content must be a string!').isLength({ min: 1, max: 2000 }).withMessage('Content length must be between 1 and 2000 characters.'),
     body('socketId').optional(true).isString().withMessage('SocketId must be a string!').isLength({ min: 1, max: 255 }).withMessage('SocketId length must be between 1 and 255 characters.'),
+    body('avatarUrl').optional(true).isString().withMessage('Avatar URL must be a string!').isLength({ min: 1, max: 255 }).withMessage('Avatar URL length must be between 1 and 255 characters.'),
+    body('username').optional(true).isString().withMessage('Invalid username.').not().contains('@').withMessage('Username cannot contain the @ symbol').not().contains(':').withMessage('Username cannot contain the : symbol').isLength({ min: 3, max: 35 }).withMessage('Username must be between 3 and 35 characters long.'),
 
     body('replyToMessageIds')
       .optional(true)
@@ -123,6 +125,8 @@ interface Body {
   mentionReplies?: boolean;
   silent?: boolean;
   nerimityCdnFileId?: string;
+  avatar_url_override?: string;
+  username_override?: string;
   googleDriveAttachment?: {
     id: string;
     mime: string;
@@ -262,6 +266,14 @@ async function route(req: Request, res: Response) {
 
   const [canMentionRoles] = memberHasRolePermission(req, ROLE_PERMISSIONS.MENTION_ROLES);
 
+  const [canMasquerade] = memberHasRolePermission(req, ROLE_PERMISSIONS.MASQUERADE);
+  
+  if (body.avatar_url_override?.trim() || body.username_override?.trim()) {
+  if (!canMasquerade) {
+    return res.status(403).json(generateError('You do not have permission to masquerade yourself.'));
+  }
+}
+
   let attachment: Partial<Attachment> | undefined = undefined;
 
   if (body.nerimityCdnFileId) {
@@ -325,6 +337,8 @@ async function route(req: Request, res: Response) {
     channel: req.channelCache,
     serverId: req.channelCache?.server?.id,
     member: req.serverMemberCache,
+    avatar_url_override: body.avatar_url_override,
+    username_override: body.username_override,
     replyToMessageIds: body.replyToMessageIds,
     mentionReplies: body.mentionReplies,
     server: req.serverCache,

--- a/src/services/Message/Message.ts
+++ b/src/services/Message/Message.ts
@@ -128,9 +128,7 @@ export function transformMessage(message: TransformMessage) {
         username: message.webhook.name,
         avatar: message.webhook.avatar,
         hexColor: message.webhook.hexColor,
-        ...(message.creatorOverride?.username && { username: message.creatorOverride.username }),
         ...(message.creatorOverrideId && { id: message.webhookId! + '-' + message.creatorOverrideId }),
-        ...(message.creatorOverride?.avatarUrl && { avatarUrl: (message.creatorOverride.animatedAvatar ? 'a' : '') + message.creatorOverride.avatarUrl }),
       };
 
       return createdBy;

--- a/src/services/Message/Message.ts
+++ b/src/services/Message/Message.ts
@@ -136,7 +136,11 @@ export function transformMessage(message: TransformMessage) {
       return createdBy;
     }
 
-    return { ...newMessage.createdBy };
+    return { 
+      ...newMessage.createdBy,
+      ...(message.creatorOverride?.username && { username: message.creatorOverride.username }),
+      ...(message.creatorOverride?.avatarUrl && { avatarUrl: (message.creatorOverride.animatedAvatar ? 'a' : '') + message.creatorOverride.avatarUrl }),
+     };
   })();
 
   return { ...newMessage, htmlEmbed, createdBy };


### PR DESCRIPTION
# Pull Request Template 

## What does this PR do?
<!-- Describe the purpose of this PR and what changes it introduces. -->
- This little PR adds support for the Masquerade feature to the backend

## Changes Made
- `src/common/Bitwise.ts`, Added the role permision (its bit 9)
- `src/routes/channels/channelMessageCreate.ts`, added the check if the user has the permision and added the coresponding things to the interfaces
- `src/services/Message/Message.ts`, added the creator override content to make sure that the frontend gets the masquerade data

## Checklist
- [x] Code is clear, concise & easy to understand
- [x] Code has been tested and works as intended  
- [ ] Documentation or README has been updated if relevant  
- [ ] Security and error handling considerations have been addressed  
- [ ] Has the change been previously discussed with backend maintainer(s)

## Testing
<!-- Describe how you tested your changes. -->
- I spined up a local instance of Nerimity with the imgproxy, client (that from the PR in `Additional Notes`), proxy, cdn and server
- I used Bruno to test if the endpoints corectly reponds if a `avatar_url_override` or `username_override` exists in the request body of the route
- I checked with the client if the messages are corectly displayed and if nothing is broken (i hope that i dont broke stuff)

## Additional Notes
- Client PR: https://github.com/Nerimity/nerimity-web/pull/671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Masquerade** permission that enables per-message identity overrides for permitted users (custom name and avatar).
  * Messages can now accept optional `username` and `avatar` overrides (with validation) during message creation.
* **Bug Fixes**
  * Improved message identity handling so webhook-created messages use webhook identity data without applying masquerade overrides.
* **Chores**
  * Added safeguards to require the Masquerade permission for impersonation overrides and to block masquerading in direct messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->